### PR TITLE
Fix zip structure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,5 @@ phpunit.xml              export-ignore
 README.md                export-ignore
 renovate.json            export-ignore
 test.php                 export-ignore
+.DS_Store                export-ignore
+.aider*                  export-ignore

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,10 @@ package:
 	@echo "Updating version to $(VERSION) in module.ini..."
 	$(SED_INPLACE) 's/^\([[:space:]]*version[[:space:]]*=[[:space:]]*\).*$$/\1"$(VERSION)"/' config/module.ini
 	@echo "Creating ZIP archive: ThreeDViewer-$(VERSION).zip..."
-	composer archive --format=zip --file="ThreeDViewer-$(VERSION)"
+	composer archive --format=zip --file="ThreeDViewer-$(VERSION)-raw"
+	@echo "Repacking into proper structure..."
+	mkdir -p tmpzip/ThreeDViewer && unzip -q ThreeDViewer-$(VERSION)-raw.zip -d tmpzip/ThreeDViewer && \
+	cd tmpzip && zip -qr ../ThreeDViewer-$(VERSION).zip ThreeDViewer && cd .. && rm -rf tmpzip ThreeDViewer-$(VERSION)-raw.zip
 	@echo "Restoring version to 0.0.0 in module.ini..."
 	$(SED_INPLACE) 's/^\([[:space:]]*version[[:space:]]*=[[:space:]]*\).*$$/\1"0.0.0"/' config/module.ini
 


### PR DESCRIPTION
This pull request includes updates to the `.gitattributes` file and modifications to the `Makefile` to improve the packaging process.

Changes to `.gitattributes`:

* Added `.DS_Store` and `.aider*` to the export-ignore list to prevent these files from being included in exports.

Improvements to packaging process in `Makefile`:

* Updated the packaging command to create a temporary directory structure for the ZIP archive, ensuring the final ZIP file has the correct structure.